### PR TITLE
Fix improper port-binding for service container

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -8,7 +8,9 @@ services:
     environment:
       - APP_NAME=VulnerableScreenshotService
     volumes:
-       - display-image:/app
+      - display-image:/app
+    ports:
+      - "8888:8888"
 
   nginx:
      build: ./nginx

--- a/vuln-screenshot/Dockerfile
+++ b/vuln-screenshot/Dockerfile
@@ -15,8 +15,6 @@ RUN apt -y install ./google-chrome-stable_current_amd64.deb
 
 FROM base
 
-EXPOSE 5000
-
 #caches the pip install step
 ADD requirements.txt /app/requirements.txt
 WORKDIR /app


### PR DESCRIPTION
The `vuln-screenshot` / flask container which runs the admin service does not properly expose the port needed to access the service (tcp/8888), without which the service is not accessible. It just needs to have this port added to the `docker-compose.yml` file service definition. We can also remove an extraneous `EXPOSE` directive from `./vuln-screenshot/Dockerfile`.